### PR TITLE
Manage users

### DIFF
--- a/API-DOCS.md
+++ b/API-DOCS.md
@@ -371,10 +371,10 @@ Update a user
 ### Request
 
 `:id` (path): The user to update
-`email` (body): [Optional] Email address
-`googleID` (body): Google ID
-`schoolID` (body): [Optional] School ID
 `name` (body): Name
+`googleID` (body): Google ID
+`email` (body): [Optional] Email address
+`schoolID` (body): [Optional] School ID
 `balance` (body): [Optional] Balance
 `balanceExpires` (body): [Optional] Balance expiry date (ISO or epoch MS)
 `weeklyBalanceMultiplier` (body): [Optional] Weekly balance multiplier
@@ -403,9 +403,10 @@ Create a user
 ### Request
 
 `email` (body): [Optional] Email address
-`googleID` (body): Google ID
-`schoolID` (body): [Optional] School ID
 `name` (body): Name
+`googleID` (body): Google ID
+`email` (body): [Optional] Email address
+`schoolID` (body): [Optional] School ID
 `balance` (body): [Optional] Balance
 `balanceExpires` (body): [Optional] Balance expiry date (ISO or epoch MS)
 `weeklyBalanceMultiplier` (body): [Optional] Weekly balance multiplier

--- a/API-DOCS.md
+++ b/API-DOCS.md
@@ -374,7 +374,7 @@ Update a user
 `email` (body): [Optional] Email address
 `googleID` (body): Google ID
 `schoolID` (body): [Optional] School ID
-`name` (body): [Optional] Name
+`name` (body): Name
 `balance` (body): [Optional] Balance
 `balanceExpires` (body): [Optional] Balance expiry date (ISO or epoch MS)
 `weeklyBalanceMultiplier` (body): [Optional] Weekly balance multiplier
@@ -405,7 +405,7 @@ Create a user
 `email` (body): [Optional] Email address
 `googleID` (body): Google ID
 `schoolID` (body): [Optional] School ID
-`name` (body): [Optional] Name
+`name` (body): Name
 `balance` (body): [Optional] Balance
 `balanceExpires` (body): [Optional] Balance expiry date (ISO or epoch MS)
 `weeklyBalanceMultiplier` (body): [Optional] Weekly balance multiplier

--- a/API-DOCS.md
+++ b/API-DOCS.md
@@ -375,7 +375,7 @@ Update a user
 `googleID` (body): Google ID
 `email` (body): [Optional] Email address
 `schoolID` (body): [Optional] School ID
-`balance` (body): [Optional] Balance
+`balance` (body): Balance
 `balanceExpires` (body): [Optional] Balance expiry date (ISO or epoch MS)
 `weeklyBalanceMultiplier` (body): [Optional] Weekly balance multiplier
 `roles` (body): [Optional] Roles to give to the user as an arry of strings

--- a/API-DOCS.md
+++ b/API-DOCS.md
@@ -110,6 +110,8 @@ Body:
 }
 ```
 
+see [db schema](src/types/db.ts) for `ITransactionAPIResponse`
+
 ## DELETE `/transactions/:id`
 
 Delete a transaction.
@@ -138,21 +140,7 @@ None
 
 `classIDs`, `managers`, `users`, and `owner` will only be returned if you can manage this store.
 
-```ts
-{
-	_id: string,
-	name: string,
-	description: string | null,
-	canManage: boolean,
-	public: boolean,
-	classNames: string[]
-	classIDs: string[] | null,
-	managers: string[] | null,
-	users: string[] | null,
-	owner: string | null
-}
-[],
-```
+`IStoreAPIResponse[]` (see [db schema](src/types/db.ts))
 
 ## POST `/stores`
 
@@ -171,25 +159,7 @@ Create a store. Requires staff permissions.
 
 `classIDs`, `managers`, `users`, and `owner` will only be returned if you can manage this store.
 
-```ts
-{
-	name: string,
-	description: string | null,
-	public: boolean,
-	canManage: boolean,
-	classNames: string[],
-	classIDs: string[] | undefined,
-	owner: string | undefined,
-	users: {
-		name: string;
-		id: string;
-	}[] | undefined,
-	managers: {
-		name: string;
-		id: string;
-	}[] | undefined,
-}[]
-```
+`IStoreAPIResponse` (see [db schema](src/types/db.ts))
 
 ## GET `/store/:id`
 
@@ -203,24 +173,7 @@ Get a store's info by its ID
 
 `classIDs`, `managers`, `users`, and `owner` will only be returned if you can manage this store.
 
-```ts
-{
-	name: string,
-	description: string | null,
-	public: boolean,
-	canManage: boolean,
-	classIDs: string[] | undefined,
-	owner: string | undefined,
-	users: {
-		name: string;
-		id: string;
-	}[] | undefined,
-	managers: {
-		name: string;
-		id: string;
-	}[] | undefined,
-}
-```
+`IStoreAPIResponse` (see [db schema](src/types/db.ts))
 
 ## PATCH `/store/:id`
 
@@ -238,25 +191,7 @@ Update a store. Requires permission to manage this store.
 
 ### Response
 
-```ts
-{
-	name: string,
-	description: string | null,
-	public: boolean,
-	canManage: boolean,
-	classNames: string[],
-	classIDs: string[] | undefined,
-	owner: string | undefined,
-	users: {
-		name: string;
-		id: string;
-	}[] | undefined,
-	managers: {
-		name: string;
-		id: string;
-	}[] | undefined,
-}
-```
+`IStoreAPIResponse` (see [db schema](src/types/db.ts))
 
 ## DELETE `/store/:id`
 
@@ -292,17 +227,7 @@ Get a list of a store's items
 
 ### Response
 
-```ts
-{
-	_id: string,
-	name: string,
-	description: string,
-	quantity: number | null,
-	price: number,
-	imageHash: string | null
-}
-[],
-```
+`IStoreItem[]` (see [db schema](src/types/db.ts))
 
 ## GET `/store/:storeID/item/:id`
 
@@ -315,16 +240,7 @@ Get a store's item by its ID
 
 ### Response
 
-```ts
-{
-	_id: string,
-	name: string,
-	description: string,
-	quantity: number | null,
-	price: number,
-	imageHash: string | null
-}
-```
+`IStoreItem` (see [db schema](src/types/db.ts))
 
 ## GET `/store/:storeID/item/:id/image`
 
@@ -354,16 +270,7 @@ Update a store's item
 
 ### Response
 
-```ts
-{
-	_id: string,
-	name: string,
-	description: string,
-	quantity: number | null,
-	price: number,
-	imageHash: string | null
-}
-```
+`IStoreItem` (see [db schema](src/types/db.ts))
 
 ## PATCH `/store/:storeID/item/:id/image`
 
@@ -416,39 +323,11 @@ Create a store item
 
 ### Response
 
-```ts
-{
-	_id: string,
-	name: string,
-	description: string,
-	quantity: number | null,
-	price: number,
-	imageHash: null
-}
-```
+`IStoreItem` (see [db schema](src/types/db.ts))
 
 # Users
 
-## PATCH `/roles`
-
-Update a user's roles. Requires admin role.
-
-### Request
-
-Body:
-
-```ts
-{
-	user: string; // User ID
-	roles: ("NONE" | "STUDENT" | "STAFF" | "ADMIN" | "ALL")[]
-}
-```
-
-### Response
-
-User object
-
-## GET `/search`
+## GET `/users/search`
 
 Search for users
 
@@ -473,23 +352,65 @@ Body:
 [],
 ```
 
-## GET `/me`
+## GET `/users/:id`
 
-Get info for authenticated user
+Get info for authenticated user. Requires admin role for retrieving other users.
 
 ### Request
 
-None
+`:id` (path): The user to get, or `me` to get for the authenticated user
 
 ### Response
 
-```ts
-{
-	name: string,
-	email: string,
-	id: string,
-	roles: ("NONE" | "STUDENT" | "STAFF" | "ADMIN" | "ALL")[]
-	scopes: string[]
-	authorized: boolean; // Valid OAuth Credentials
-}
-```
+`IUserAPIResponse` (see [db schema](src/types/db.ts))
+
+## PATCH `/users/:id`
+
+Update a user
+
+### Request
+
+`:id` (path): The user to update
+`email` (body): [Optional] Email address
+`googleID` (body): Google ID
+`schoolID` (body): [Optional] School ID
+`name` (body): [Optional] Name
+`balance` (body): [Optional] Balance
+`balanceExpires` (body): [Optional] Balance expiry date (ISO or epoch MS)
+`weeklyBalanceMultiplier` (body): [Optional] Weekly balance multiplier
+`roles` (body): [Optional] Roles to give to the user as an arry of strings
+
+### Response
+
+`IUserAPIResponse` (see [db schema](src/types/db.ts))
+
+## DELETE `/users/:id`
+
+Delete a user
+
+### Request
+
+`:id` (path): The user to update
+
+### Response
+
+Nothing
+
+## POST `/users`
+
+Create a user
+
+### Request
+
+`email` (body): [Optional] Email address
+`googleID` (body): Google ID
+`schoolID` (body): [Optional] School ID
+`name` (body): [Optional] Name
+`balance` (body): [Optional] Balance
+`balanceExpires` (body): [Optional] Balance expiry date (ISO or epoch MS)
+`weeklyBalanceMultiplier` (body): [Optional] Weekly balance multiplier
+`roles` (body): [Optional] Roles to give to the user as an arry of strings
+
+### Response
+
+`IUserAPIResponse` (see [db schema](src/types/db.ts))

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -37,7 +37,7 @@ async function searchUsers(search, count, roles, me) {
 	if (count !== null && count !== undefined) params.append('count', count);
 	if (me !== null && me !== undefined) params.append('me', me);
 	if (roles) params.append('roles', roles.join(','));
-	const res = await fetch(`/api/search?${params.toString()}`).catch(
+	const res = await fetch(`/api/users/search?${params.toString()}`).catch(
 		e => null,
 	);
 	if (res && res.ok) {
@@ -91,7 +91,7 @@ async function getClassStudents(id) {
 }
 
 async function getUserInfo() {
-	const info = await fetch('/api/me').catch(e => null);
+	const info = await fetch('/api/users/me').catch(e => null);
 	if (info && info.ok) {
 		try {
 			let userInfo = await info.json();

--- a/src/helpers/request.ts
+++ b/src/helpers/request.ts
@@ -501,6 +501,6 @@ export class Validators {
 	/** Valid role */
 	static role = () => ({
 		run: (data: unknown) => typeof data == 'string' && isValidRole(data),
-		errorMessage: 'Invalid role',
+		errorMessage: '{KEY} must be a valid role',
 	});
 }

--- a/src/helpers/request.ts
+++ b/src/helpers/request.ts
@@ -447,19 +447,24 @@ export class Validators {
 
 	/**
 	 * Valid currency amount
+	 * @param canBeZero If true, zero is a valid amount
 	 */
-	static currency = () => ({
-		run: Validators.and(Validators.anyNumber, Validators.gt(0), {
-			run: (data: unknown): boolean | string => {
-				if (!Validators.anyNumber().run(data))
-					return '{KEY} must be a number';
-				return (
-					Math.round(numberFromData(data) * 100) / 100 ==
-					numberFromData(data)
-				);
+	static currency = (canBeZero: boolean = false) => ({
+		run: Validators.and(
+			Validators.anyNumber,
+			(canBeZero ? Validators.gte : Validators.gt)(0),
+			{
+				run: (data: unknown): boolean | string => {
+					if (!Validators.anyNumber().run(data))
+						return '{KEY} must be a number';
+					return (
+						Math.round(numberFromData(data) * 100) / 100 ==
+						numberFromData(data)
+					);
+				},
+				errorMessage: '{KEY} cannot have more than 2 decimal places',
 			},
-			errorMessage: '{KEY} cannot have more than 2 decimal places',
-		}).run,
+		).run,
 	});
 
 	/** Valid mongoBD object ID */

--- a/src/helpers/schema.ts
+++ b/src/helpers/schema.ts
@@ -136,6 +136,7 @@ userSchema.methods.toAPIResponse = async function (
 		getters: true,
 		versionKey: false,
 	});
+	delete noTokens.id;
 
 	let roles = this.getRoles();
 	let scopes = this.tokens?.scopes;
@@ -265,10 +266,11 @@ transactionSchema.methods.canManage = function (user?: IUserDoc): boolean {
 transactionSchema.methods.toAPIResponse = async function (
 	user?: IUserDoc,
 ): Promise<ITransactionAPIResponse> {
-	let json: Omit<ITransaction, 'date'> = this.toObject({
+	let json = this.toObject({
 		getters: true,
 		versionKey: false,
 	});
+	delete json.id;
 
 	let res: ITransactionAPIResponse = {
 		...json,
@@ -318,6 +320,7 @@ storeSchema.methods.toAPIResponse = async function (
 		getters: true,
 		versionKey: false,
 	});
+	delete data.id;
 
 	if (!canManage) {
 		let res: IStoreAPIResponse = {

--- a/src/helpers/schema.ts
+++ b/src/helpers/schema.ts
@@ -48,6 +48,7 @@ const userSchema = new mongoose.Schema<IUserDoc, IUserModel>({
 	},
 	name: {
 		type: String,
+		required: true,
 	},
 	balance: {
 		type: Number,

--- a/src/helpers/schema.ts
+++ b/src/helpers/schema.ts
@@ -25,6 +25,7 @@ import {
 	IError,
 	IErrorDetail,
 	IStoreAPIResponse,
+	IUserAPIResponse,
 } from '../types';
 
 import fuzzySearch from 'mongoose-fuzzy-searching';
@@ -124,6 +125,22 @@ userSchema.methods.hasAnyRole = function (roles: UserRoleTypes[]): boolean {
 
 userSchema.methods.hasAllRoles = function (roles: UserRoleTypes[]): boolean {
 	return roles.every(role => this.hasRole(role));
+};
+
+userSchema.methods.toAPIResponse = function (): IUserAPIResponse {
+	let {tokens, ...noTokens} = this.toObject({
+		getters: true,
+		versionKey: false,
+	});
+
+	let roles = this.getRoles();
+
+	let data: IUserAPIResponse = {
+		...noTokens,
+		roles,
+	};
+
+	return data;
 };
 
 function getBalance(this: IUserDoc, balance: number) {
@@ -238,7 +255,10 @@ transactionSchema.methods.canManage = function (user?: IUserDoc): boolean {
 transactionSchema.methods.toAPIResponse = async function (
 	user?: IUserDoc,
 ): Promise<ITransactionAPIResponse> {
-	let json: Omit<ITransaction, 'date'> = this.toJSON();
+	let json: Omit<ITransaction, 'date'> = this.toObject({
+		getters: true,
+		versionKey: false,
+	});
 
 	let res: ITransactionAPIResponse = {
 		...json,
@@ -284,7 +304,10 @@ storeSchema.methods.getItems = async function (): Promise<IStoreItemDoc[]> {
 storeSchema.methods.toAPIResponse = async function (
 	canManage: boolean,
 ): Promise<IStoreAPIResponse> {
-	let data = this.toJSON();
+	let data = this.toObject({
+		getters: true,
+		versionKey: false,
+	});
 
 	if (!canManage) {
 		let res: IStoreAPIResponse = {

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -95,14 +95,17 @@ export interface IUserMethods {
 	hasAllRoles(roles: UserRoleTypes[]): boolean;
 	/**
 	 * Turn this transaction into a JSON object for API output
+	 * @param checkAuthorized Check if user has authorized OAuth
 	 */
-	toAPIResponse(): IUserAPIResponse;
+	toAPIResponse(checkAuthorized?: boolean): Promise<IUserAPIResponse>;
 }
 
 export type IUserAPIResponse = Modify<
 	IUser,
 	{
 		roles: UserRoleTypes[];
+		authorized?: boolean;
+		scopes: string[];
 	},
 	'tokens'
 >;

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -27,7 +27,7 @@ export interface IUser {
 	/**
 	 * The user's name
 	 */
-	name?: string;
+	name: string;
 	tokens: {
 		/**
 		 * OAuth refresh token

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -93,7 +93,19 @@ export interface IUserMethods {
 	 * @param role The roles to check for
 	 */
 	hasAllRoles(roles: UserRoleTypes[]): boolean;
+	/**
+	 * Turn this transaction into a JSON object for API output
+	 */
+	toAPIResponse(): IUserAPIResponse;
 }
+
+export type IUserAPIResponse = Modify<
+	IUser,
+	{
+		roles: UserRoleTypes[];
+	},
+	'tokens'
+>;
 
 export type IUserDoc = IUser & IUserMethods & Document<IUser>;
 

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -15,7 +15,7 @@ export interface IUser {
 	/**
 	 * The user's email
 	 */
-	email: string | null;
+	email?: string;
 	/**
 	 * The user's Google ID
 	 */
@@ -23,11 +23,11 @@ export interface IUser {
 	/**
 	 * The user's school ID
 	 */
-	schoolID: string;
+	schoolID?: string;
 	/**
 	 * The user's name
 	 */
-	name: string | null;
+	name?: string;
 	tokens: {
 		/**
 		 * OAuth refresh token

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,7 +9,7 @@ export function notEmpty<T>(value: T | null | undefined): value is T {
 /**
  * @param T Original type
  * @param R Add/Replace these keys
- * @param D Delete they keys
+ * @param D Delete these keys
  */
 export type Modify<T, R, D extends keyof any = never> = Omit<T, keyof R | D> &
 	R;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,4 +6,10 @@ export function notEmpty<T>(value: T | null | undefined): value is T {
 	return value !== null && value !== undefined;
 }
 
-export type Modify<T, R> = Omit<T, keyof R> & R;
+/**
+ * @param T Original type
+ * @param R Add/Replace these keys
+ * @param D Delete they keys
+ */
+export type Modify<T, R, D extends keyof any = never> = Omit<T, keyof R | D> &
+	R;

--- a/src/webserver/routes/api/users.ts
+++ b/src/webserver/routes/api/users.ts
@@ -25,7 +25,7 @@ router.post(
 					googleID: Validators.string,
 					schoolID: Validators.optional(Validators.string),
 					name: Validators.string,
-					balance: Validators.optional(Validators.currency),
+					balance: Validators.optional(Validators.currency(true)),
 					balanceExpires: Validators.optional(Validators.date),
 					weeklyBalanceMultiplier: Validators.optional(
 						Validators.number,
@@ -135,7 +135,7 @@ router.patch(
 					googleID: Validators.string,
 					schoolID: Validators.optional(Validators.string),
 					name: Validators.string,
-					balance: Validators.currency,
+					balance: Validators.currency(true),
 					balanceExpires: Validators.optional(Validators.date),
 					weeklyBalanceMultiplier: Validators.optional(
 						Validators.number,

--- a/src/webserver/routes/api/users.ts
+++ b/src/webserver/routes/api/users.ts
@@ -13,36 +13,115 @@ import {getAccessToken} from '../../../helpers/oauth';
 import {FilterQuery} from 'mongoose';
 const router = express.Router();
 
-router.patch(
-	'/roles',
+interface user {
+	/**
+	 * The user's email
+	 */
+	email: string | null;
+	/**
+	 * The user's Google ID
+	 */
+	googleID: string;
+	/**
+	 * The user's school ID
+	 */
+	schoolID: string;
+	/**
+	 * The user's name
+	 */
+	name: string | null;
+	tokens: {
+		/**
+		 * OAuth refresh token
+		 */
+		refresh: string | null;
+		/**
+		 * OAuth access token
+		 */
+		access: string | null;
+		/**
+		 * OAuth access token expiration date
+		 */
+		expires: Date | null;
+		/**
+		 * Session token
+		 */
+		session: string | null;
+		/**
+		 * Authorized scopes
+		 */
+		scopes: string[];
+	};
+	/**
+	 * The user's balance
+	 */
+	balance: number;
+	/**
+	 * Staff - when their balance resets
+	 */
+	balanceExpires?: Date;
+	/**
+	 * Staff - multiplier for weekly balance
+	 */
+	weeklyBalanceMultiplier?: number;
+	/**
+	 * The user's roles (bitfield)
+	 */
+	roles: number;
+}
+
+router.post(
+	'/users',
 	async (req, res, next) =>
 		request(req, res, next, {
 			authentication: true,
 			roles: ['ADMIN'],
 			validators: {
 				body: {
-					user: Validators.objectID,
-					roles: {
-						run: (data: unknown) =>
-							typeof data == 'string' && isValidRoles(data),
-						errorMessage: 'Invalid roles list',
-					},
+					email: Validators.optional(Validators.string),
+					googleID: Validators.string,
+					schoolID: Validators.optional(Validators.string),
+					name: Validators.optional(Validators.string),
+					balance: Validators.optional(Validators.currency),
+					balanceExpires: Validators.optional(Validators.date),
+					weeklyBalanceMultiplier: Validators.optional(
+						Validators.number,
+					),
+					roles: Validators.optional(
+						Validators.array(Validators.role),
+					),
 				},
 			},
 		}),
 	async (req, res) => {
 		try {
-			if (!requestHasUser(req)) return;
+			let {body} = req;
 
-			let {user, roles} = req.body;
+			let data = {
+				email: body.email,
+				googleID: body.googleID,
+				schoolID: body.schoolID,
+				name: body.name,
+				balance: body.balance,
+				balanceExpires: body.balanceExpires,
+				weeklyBalanceMultiplier: body.weeklyBalanceMultiplier,
+				roles: body.roles || [],
+			};
 
-			const dbUser = await User.findById(user);
-			if (!dbUser) return res.status(404).send('Invalid user');
-
-			dbUser.setRoles(roles);
-			await dbUser.save();
-
-			res.status(200).send(dbUser);
+			let user = await new User(data).save().catch(async e => {
+				const error = await DBError.generate(
+					{
+						request: req,
+						error: e instanceof Error ? e : undefined,
+					},
+					{
+						user: req.user?.id,
+					},
+				);
+				res.status(500).send(`An error occured. Error ID: ${error.id}`);
+			});
+			if (!user) return;
+			res.status(200).send(user);
 		} catch (e) {
 			try {
 				const error = await DBError.generate(
@@ -54,13 +133,26 @@ router.patch(
 						user: req.user?.id,
 					},
 				);
-				res.status(500).send(
-					`Something went wrong. Error ID: ${error.id}`,
-				);
+				res.status(500).send(`An error occured. Error ID: ${error.id}`);
 			} catch (e) {}
 		}
 	},
 );
+
+/**
+ * @todo
+ */
+router.get('/users/:id');
+
+/**
+ * @todo
+ */
+router.patch('/users/:id');
+
+/**
+ * @todo
+ */
+router.delete('/users/:id');
 
 // Get my info
 router.get(

--- a/src/webserver/routes/api/users.ts
+++ b/src/webserver/routes/api/users.ts
@@ -24,7 +24,7 @@ router.post(
 					email: Validators.optional(Validators.string),
 					googleID: Validators.string,
 					schoolID: Validators.optional(Validators.string),
-					name: Validators.optional(Validators.string),
+					name: Validators.string,
 					balance: Validators.optional(Validators.currency),
 					balanceExpires: Validators.optional(Validators.date),
 					weeklyBalanceMultiplier: Validators.optional(
@@ -134,7 +134,7 @@ router.patch(
 					email: Validators.optional(Validators.string),
 					googleID: Validators.string,
 					schoolID: Validators.optional(Validators.string),
-					name: Validators.optional(Validators.string),
+					name: Validators.string,
 					balance: Validators.optional(Validators.currency),
 					balanceExpires: Validators.optional(Validators.date),
 					weeklyBalanceMultiplier: Validators.optional(

--- a/src/webserver/routes/api/users.ts
+++ b/src/webserver/routes/api/users.ts
@@ -7,7 +7,12 @@ import {
 	UserRoles,
 	UserRoleTypes,
 } from '../../../helpers/schema';
-import {booleanFromData, request, Validators} from '../../../helpers/request';
+import {
+	booleanFromData,
+	dateFromData,
+	request,
+	Validators,
+} from '../../../helpers/request';
 import {IUserDoc, requestHasUser} from '../../../types';
 import {getAccessToken} from '../../../helpers/oauth';
 import {FilterQuery} from 'mongoose';
@@ -46,7 +51,7 @@ router.post(
 				schoolID: body.schoolID,
 				name: body.name,
 				balance: body.balance,
-				balanceExpires: body.balanceExpires,
+				balanceExpires: dateFromData(body.balanceExpires),
 				weeklyBalanceMultiplier: body.weeklyBalanceMultiplier,
 			};
 
@@ -156,7 +161,7 @@ router.patch(
 				schoolID: body.schoolID,
 				name: body.name,
 				balance: body.balance,
-				balanceExpires: body.balanceExpires,
+				balanceExpires: dateFromData(body.balanceExpires),
 				weeklyBalanceMultiplier: body.weeklyBalanceMultiplier,
 			};
 

--- a/src/webserver/routes/api/users.ts
+++ b/src/webserver/routes/api/users.ts
@@ -205,7 +205,7 @@ router.delete('/users/:id');
 
 // Search users
 router.get(
-	'/search',
+	'/users/search',
 	async (req, res, next) =>
 		request(req, res, next, {
 			authentication: true,

--- a/src/webserver/routes/api/users.ts
+++ b/src/webserver/routes/api/users.ts
@@ -13,63 +13,6 @@ import {getAccessToken} from '../../../helpers/oauth';
 import {FilterQuery} from 'mongoose';
 const router = express.Router();
 
-interface user {
-	/**
-	 * The user's email
-	 */
-	email: string | null;
-	/**
-	 * The user's Google ID
-	 */
-	googleID: string;
-	/**
-	 * The user's school ID
-	 */
-	schoolID: string;
-	/**
-	 * The user's name
-	 */
-	name: string | null;
-	tokens: {
-		/**
-		 * OAuth refresh token
-		 */
-		refresh: string | null;
-		/**
-		 * OAuth access token
-		 */
-		access: string | null;
-		/**
-		 * OAuth access token expiration date
-		 */
-		expires: Date | null;
-		/**
-		 * Session token
-		 */
-		session: string | null;
-		/**
-		 * Authorized scopes
-		 */
-		scopes: string[];
-	};
-	/**
-	 * The user's balance
-	 */
-	balance: number;
-	/**
-	 * Staff - when their balance resets
-	 */
-	balanceExpires?: Date;
-	/**
-	 * Staff - multiplier for weekly balance
-	 */
-	weeklyBalanceMultiplier?: number;
-	/**
-	 * The user's roles (bitfield)
-	 */
-	roles: number;
-}
-
 router.post(
 	'/users',
 	async (req, res, next) =>

--- a/src/webserver/routes/api/users.ts
+++ b/src/webserver/routes/api/users.ts
@@ -203,29 +203,6 @@ router.patch(
  */
 router.delete('/users/:id');
 
-// Get my info
-router.get(
-	'/me',
-	async (req, res, next) =>
-		request(req, res, next, {
-			authentication: true,
-		}),
-	async (req, res) => {
-		if (!requestHasUser(req)) return;
-
-		let json = req.user.toAPIResponse();
-
-		let authorized = !!(await getAccessToken(req.user));
-		let scopes = req.user.tokens?.scopes;
-
-		res.status(200).send({
-			...json,
-			authorized,
-			scopes,
-		});
-	},
-);
-
 // Search users
 router.get(
 	'/search',

--- a/src/webserver/routes/api/users.ts
+++ b/src/webserver/routes/api/users.ts
@@ -135,7 +135,7 @@ router.patch(
 					googleID: Validators.string,
 					schoolID: Validators.optional(Validators.string),
 					name: Validators.string,
-					balance: Validators.optional(Validators.currency),
+					balance: Validators.currency,
 					balanceExpires: Validators.optional(Validators.date),
 					weeklyBalanceMultiplier: Validators.optional(
 						Validators.number,

--- a/src/webserver/routes/api/users.ts
+++ b/src/webserver/routes/api/users.ts
@@ -96,7 +96,7 @@ router.get(
 
 			const user =
 				userID == 'me' ? req.user : await User.findById(userID);
-			if (!user) return res.status(404).send('Invalid user');
+			if (!user) return res.status(404).send('User not found');
 
 			res.status(200).send(
 				await user.toAPIResponse(user.id == req.user.id),

--- a/src/webserver/routes/api/users.ts
+++ b/src/webserver/routes/api/users.ts
@@ -160,10 +160,8 @@ router.patch(
 				weeklyBalanceMultiplier: body.weeklyBalanceMultiplier,
 			};
 
-			let user = await User.findById(req.params.id).catch(e => {
-				res.status(400).send('User not found');
-			});
-			if (!user) return;
+			let user = await User.findById(req.params.id);
+			if (!user) return res.status(404).send('User not found');
 
 			user = Object.assign(user, data) as typeof user;
 			if (body.roles) user.setRoles(body.roles);
@@ -197,10 +195,8 @@ router.delete(
 		}),
 	async (req, res) => {
 		try {
-			let user = await User.findById(req.params.id).catch(e => {
-				res.status(400).send('User not found');
-			});
-			if (!user) return;
+			let user = await User.findById(req.params.id);
+			if (!user) return res.status(404).send('User not found');
 
 			await user.remove();
 


### PR DESCRIPTION
This adds API routes for CRUD operations on users:
- POST `/users`
- GET `/user/:id`
- PATCH `/user/:id`
- DELETE `/user/:id`
For more info, see the [API docs](https://github.com/codeths/kitcoin/blob/70ba32797fee2777c223f9868467a2d8dd3cdd7b/API-DOCS.md).
These routes can be used on the admin dashboard (#37).

It also:
- Merges `/me` into `/user/:id` (`:id` can be `me`)
- Moves `/search` to `/users/search/` for consistency
- Improves some typings
- Improve responses in API docs
- Other misc fixes