### PR TITLE
Sync users

### DIFF
--- a/API-DOCS.md
+++ b/API-DOCS.md
@@ -414,3 +414,15 @@ Create a user
 ### Response
 
 `IUserAPIResponse` (see [db schema](src/types/db.ts))
+
+## GET `/users/sync`
+
+Start a request to sync users with Google Admin.
+
+### Request
+
+None
+
+### Response
+
+None

--- a/README.md
+++ b/README.md
@@ -54,21 +54,23 @@ If you would like to watch for file changes and automatically execute the approp
 
 # Config
 
-| property      | type           | description                             | example                                |
-| ------------- | -------------- | --------------------------------------- | -------------------------------------- |
-| mongo         | string         | MongoDB Connection URL                  | mongodb://user:pass@127.0.0.1:27017/db |
-| port          | number         | port to listen on                       | 8000                                   |
-| client_id     | string         | Google OAuth client ID                  |                                        |
-| client_secret | string         | Google OAuth client secret              |                                        |
-| oauthDomain   | string \| null | Google OAuth domain, or null to disable | mydomain.com                           |
-| sessionSecret | string         | Session secret for Mongo                |                                        |
-| weeklyBalance | number         | Staff's weekly balance                  | 100                                    |
+| property        | type             | description                                  | example                                |
+| --------------- | ---------------- | -------------------------------------------- | -------------------------------------- |
+| mongo           | string           | MongoDB Connection URL                       | mongodb://user:pass@127.0.0.1:27017/db |
+| port            | number           | port to listen on                            | 8000                                   |
+| client_id       | string           | Google OAuth client ID                       |                                        |
+| client_secret   | string           | Google OAuth client secret                   |                                        |
+| oauthDomain     | string \| null   | Google OAuth domain, or null to disable      | mydomain.com                           |
+| sessionSecret   | string           | Session secret for Mongo                     |                                        |
+| weeklyBalance   | number           | Staff's weekly balance                       | 100                                    |
+| gadmin_domain   | string \| null   | Domain to use for Google Admin user syncing  | mydomain.com                           |
+| gadmin_staff_ou | string[] \| null | Staff OU names for Google Admin user syncing | ["Staff", "Some OU/Admins"]            |
 
 ## Google Cloud Project Setup (For OAuth)
 
 1. Create a [Google Cloud Project](https://console.cloud.google.com/projectcreate)
-2. Go to APIs & Services > Library. Enable the Google Classroom API and Google People API.
-3. Go to APIs & Services > OAuth consent screen. Setup as desired. In the scopes section, add the following: `classroom.courses.readonly` and `classroom.rosters.readonly`.
+2. Go to APIs & Services > Library. Enable the Google Classroom API, Google People API, and Admin SDK API.
+3. Go to APIs & Services > OAuth consent screen. Setup as desired.
 4. Go to APIs & Services > Credentials. Click "Create credentials" and select "OAuth client ID".
 5. Select "Web application" for the type. Add your domain to the authorized origins. For redirect URIs, add your domain with the path `/auth/cbk`.
 6. Create the Client ID. Copy the client ID and client secret to the config file as shown above.

--- a/README.md
+++ b/README.md
@@ -54,17 +54,18 @@ If you would like to watch for file changes and automatically execute the approp
 
 # Config
 
-| property        | type             | description                                  | example                                |
-| --------------- | ---------------- | -------------------------------------------- | -------------------------------------- |
-| mongo           | string           | MongoDB Connection URL                       | mongodb://user:pass@127.0.0.1:27017/db |
-| port            | number           | port to listen on                            | 8000                                   |
-| client_id       | string           | Google OAuth client ID                       |                                        |
-| client_secret   | string           | Google OAuth client secret                   |                                        |
-| oauthDomain     | string \| null   | Google OAuth domain, or null to disable      | mydomain.com                           |
-| sessionSecret   | string           | Session secret for Mongo                     |                                        |
-| weeklyBalance   | number           | Staff's weekly balance                       | 100                                    |
-| gadmin_domain   | string \| null   | Domain to use for Google Admin user syncing  | mydomain.com                           |
-| gadmin_staff_ou | string[] \| null | Staff OU names for Google Admin user syncing | ["Staff", "Some OU/Admins"]            |
+| property         | type             | description                                | example                                |
+| ---------------- | ---------------- | ------------------------------------------ | -------------------------------------- |
+| mongo            | string           | MongoDB Connection URL                     | mongodb://user:pass@127.0.0.1:27017/db |
+| port             | number           | port to listen on                          | 8000                                   |
+| client_id        | string           | Google OAuth client ID                     |                                        |
+| client_secret    | string           | Google OAuth client secret                 |                                        |
+| oauthDomain      | string \| null   | Google OAuth domain, or null to disable    | mydomain.com                           |
+| sessionSecret    | string           | Session secret for Mongo                   |                                        |
+| weeklyBalance    | number           | Staff's weekly balance                     | 100                                    |
+| gadmin_domain    | string \| null   | Domain to use for Google Admin syncing     | mydomain.com                           |
+| gadmin_staff_ou  | string[] \| null | Staff OU names for Google Admin syncing    | ["Staff", "Some OU/Admins"]            |
+| gadmin_ignore_ou | string[] \| null | Excluded OU names for Google Admin syncing | ["Old students"]                       |
 
 ## Google Cloud Project Setup (For OAuth)
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ If you would like to watch for file changes and automatically execute the approp
 | gadmin_domain    | string \| null   | Domain to use for Google Admin syncing     | mydomain.com                           |
 | gadmin_staff_ou  | string[] \| null | Staff OU names for Google Admin syncing    | ["Staff", "Some OU/Admins"]            |
 | gadmin_ignore_ou | string[] \| null | Excluded OU names for Google Admin syncing | ["Old students"]                       |
+| gadmin_sync_user | string \| null   | User to run the daily Google Admin sync as |                                        |
 
 ## Google Cloud Project Setup (For OAuth)
 

--- a/frontend/src/pages/admin/index.svelte
+++ b/frontend/src/pages/admin/index.svelte
@@ -1,6 +1,6 @@
 <script>
 	import {metatags} from '@roxi/routify';
-	import {onMount} from 'svelte';
+	import {onMount, getContext} from 'svelte';
 	import {
 		StudentSearch,
 		RoleSelect,
@@ -246,6 +246,20 @@
 	onMount(() => {
 		setData();
 	});
+
+	let ctx = getContext('userInfo');
+	let hasAdminScope = false;
+
+	(async () => {
+		let info = (await ctx) || null;
+		if (
+			info &&
+			info.scopes.includes(
+				'https://www.googleapis.com/auth/admin.directory.user.readonly',
+			)
+		)
+			hasAdminScope = true;
+	})();
 </script>
 
 <!-- Content -->
@@ -412,6 +426,46 @@
 						</p>
 					{/if}
 				{/key}
+			</div>
+		</div>
+		<div class="mx-2 my-4 col-span-12 md:col-span-6">
+			<h1 class="text-3xl font-medium mb-2">Sync Users</h1>
+			<div
+				class="bg-base-100 shadow-md rounded px-8 py-8 flex flex-col justify-center"
+			>
+				{#if hasAdminScope}
+					<button
+						class="btn btn-primary"
+						on:click={() => {
+							fetch('/api/users/sync', {
+								method: 'POST',
+							}).then(async x => {
+								if (x.ok) {
+									toastContainer.toast(
+										'Sync started',
+										'success',
+									);
+								} else {
+									let text = await x.text();
+									toastContainer.toast(
+										text || `Error ${x.status}}`,
+										'error',
+									);
+								}
+							});
+						}}
+						target="_self">Sync</button
+					>
+				{:else}
+					<span class="mb-2 text-center"
+						>You have not authorized Kitcoin to access Google Admin.</span
+					>
+					<a
+						class="btn btn-primary"
+						href="/login/admin_sync"
+						target="_self">Authorize Scope</a
+					>
+				{/if}
 			</div>
 		</div>
 	</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "kitcoin",
-	"version": "0.3.3",
+	"version": "0.4.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "kitcoin",
-			"version": "0.3.3",
+			"version": "0.4.0",
 			"license": "ISC",
 			"dependencies": {
 				"compression": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "kitcoin",
-	"version": "0.3.3",
+	"version": "0.4.0",
 	"description": "",
 	"main": "dist/index.js",
 	"scripts": {

--- a/src/config/keys.example.json
+++ b/src/config/keys.example.json
@@ -5,5 +5,10 @@
 	"client_secret": "xxxxxxxxxxxxxxxxxxxx",
 	"oauthDomain": null,
 	"sessionSecret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-	"weeklyBalance": 100
+	"weeklyBalance": 100,
+	"gadmin_domain": "xxxxx@xxxxx.xxx",
+	"gadmin_staff_ou": [
+		"xxxxx",
+		"xxxxx/yyyyy"
+	]
 }

--- a/src/config/keys.example.json
+++ b/src/config/keys.example.json
@@ -14,5 +14,6 @@
 	"gadmin_ignore_ou": [
 		"xxxxx",
 		"xxxxx/yyyyy"
-	]
+	],
+	"gadmin_sync_user": "xxxxx"
 }

--- a/src/config/keys.example.json
+++ b/src/config/keys.example.json
@@ -10,5 +10,9 @@
 	"gadmin_staff_ou": [
 		"xxxxx",
 		"xxxxx/yyyyy"
+	],
+	"gadmin_ignore_ou": [
+		"xxxxx",
+		"xxxxx/yyyyy"
 	]
 }

--- a/src/helpers/admin.ts
+++ b/src/helpers/admin.ts
@@ -29,8 +29,8 @@ export class AdminClient {
 	}
 
 	private async listUsers(pageToken?: string) {
-		if (!this.token) return null;
-		if (!gadmin_domain) return null;
+		if (!this.token) throw 'Could not authenticate for the Google API';
+		if (!gadmin_domain) throw 'Google Admin domain not set';
 
 		let data = await google.admin('directory_v1').users.list({
 			access_token: this.token,
@@ -106,7 +106,8 @@ export class AdminClient {
 	 */
 	public async processAllUsers(pageToken?: string): Promise<void> {
 		return new Promise(async (resolve, reject) => {
-			if (!this.token) return;
+			if (!this.token)
+				reject('Could not authenticate for the Google API');
 
 			let users = await this.listUsers(pageToken).catch(e => {
 				if (e && e.code && e.errors)
@@ -115,7 +116,7 @@ export class AdminClient {
 							.map((x: any) => x.message)
 							.join(', ')}`,
 					);
-				else reject();
+				else reject(e);
 			});
 			if (!users || !users.users) return;
 			resolve();

--- a/src/helpers/admin.ts
+++ b/src/helpers/admin.ts
@@ -1,0 +1,119 @@
+import Google, {google} from 'googleapis';
+import {IUserDoc} from '../types';
+import {getAccessToken} from './oauth';
+import {gadmin_domain, gadmin_staff_ou} from '../config/keys.json';
+import {User} from './schema';
+
+export class AdminClient {
+	private token?: string;
+
+	/**
+	 * Use an existing OAuth client
+	 * @param token Access Token
+	 */
+	public setToken(token: string): this {
+		this.token = token;
+
+		return this;
+	}
+
+	/**
+	 * Create an OAuth client with a user's access token
+	 * @param user DB user
+	 */
+	public async create(user: IUserDoc): Promise<this> {
+		await getAccessToken(user);
+		if (user.tokens.access) this.token = user.tokens.access;
+
+		return this;
+	}
+
+	private async listUsers(pageToken?: string) {
+		if (!this.token) return null;
+		if (!gadmin_domain) return null;
+
+		let data = await google.admin('directory_v1').users.list({
+			access_token: this.token,
+			domain: gadmin_domain,
+			maxResults: 500,
+			pageToken,
+		});
+
+		if (!data) return null;
+
+		return data.data;
+	}
+
+	private async processUser(user: Google.admin_directory_v1.Schema$User) {
+		if (!user.id) return;
+		let suspended = user.suspended || user.archived;
+		let staff =
+			gadmin_staff_ou &&
+			gadmin_staff_ou.some(ou => user.orgUnitPath?.startsWith(`/${ou}`));
+
+		let dbUser = await User.findOne().byId(user.id);
+		if (dbUser) {
+			if (suspended) {
+				await dbUser.remove();
+			} else {
+				let modified = false;
+				if (
+					user.name?.fullName &&
+					dbUser.name !== user.name?.fullName
+				) {
+					dbUser.name = user.name?.fullName;
+					modified = true;
+				}
+				if (user.primaryEmail && dbUser.email !== user.primaryEmail) {
+					dbUser.email = user.primaryEmail;
+					modified = true;
+				}
+				if (
+					staff &&
+					!dbUser.hasRole('STAFF') &&
+					!dbUser.hasRole('ADMIN')
+				) {
+					dbUser.setRoles(['STAFF']);
+					modified = true;
+				}
+				if (
+					!staff &&
+					dbUser.hasRole('STAFF') &&
+					!dbUser.hasRole('ADMIN')
+				) {
+					dbUser.setRoles(['STUDENT']);
+					modified = true;
+				}
+
+				if (modified) await dbUser.save();
+			}
+		} else if (!suspended) {
+			let newUser = new User({
+				googleID: user.id,
+				name: user.name?.fullName || 'Unknown',
+				email: user.primaryEmail,
+			});
+
+			if (staff) newUser.setRoles(['STAFF']);
+
+			await newUser.save();
+		}
+	}
+
+	/**
+	 * Sync all users with Google Admin
+	 * @param pageToken API Page Token
+	 */
+	public async processAllUsers(pageToken?: string): Promise<void> {
+		if (!this.token) return;
+
+		let users = await this.listUsers(pageToken).catch(e => {});
+		if (!users || !users.users) return;
+
+		await Promise.all(users.users.map(this.processUser));
+
+		if (users.nextPageToken)
+			return this.processAllUsers(users.nextPageToken);
+		return;
+	}
+}

--- a/src/helpers/oauth.ts
+++ b/src/helpers/oauth.ts
@@ -10,6 +10,9 @@ const OAUTH_SCOPES = {
 		'https://www.googleapis.com/auth/classroom.courses.readonly',
 		'https://www.googleapis.com/auth/classroom.rosters.readonly',
 	],
+	ADMIN_SYNC: [
+		'https://www.googleapis.com/auth/admin.directory.user.readonly',
+	],
 };
 
 type ScopeType = keyof typeof OAUTH_SCOPES;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,13 @@
+import {gadmin_sync_user} from './config/keys.json';
+import {AdminClient} from './helpers/admin';
+import {User} from './helpers/schema';
+
+// Start webserver
 import './webserver';
+
+// Start user sync
+if (gadmin_sync_user) {
+	User.findById(gadmin_sync_user).then(user => {
+		if (user) new AdminClient().startDailySyncs(user);
+	});
+}

--- a/src/webserver/routes/api/users.ts
+++ b/src/webserver/routes/api/users.ts
@@ -377,10 +377,8 @@ router.post(
 					.status(403)
 					.send('You have not authorized the required scope.');
 
-			let adminClient = await new AdminClient().create(req.user);
-
-			adminClient
-				.processAllUsers()
+			new AdminClient()
+				.startSync(req.user)
 				.then(x => {
 					res.status(200).send();
 				})

--- a/src/webserver/routes/api/users.ts
+++ b/src/webserver/routes/api/users.ts
@@ -365,40 +365,25 @@ router.post(
 			roles: ['ADMIN'],
 		}),
 	async (req, res) => {
-		try {
-			if (!requestHasUser(req)) return;
+		if (!requestHasUser(req)) return;
 
-			if (
-				!req.user.tokens.scopes.includes(
-					'https://www.googleapis.com/auth/admin.directory.user.readonly',
-				)
+		if (
+			!req.user.tokens.scopes.includes(
+				'https://www.googleapis.com/auth/admin.directory.user.readonly',
 			)
-				return res
-					.status(403)
-					.send('You have not authorized the required scope.');
+		)
+			return res
+				.status(403)
+				.send('You have not authorized the required scope.');
 
-			new AdminClient()
-				.startSync(req.user)
-				.then(x => {
-					res.status(200).send();
-				})
-				.catch(e => {
-					res.status(500).send(e);
-				});
-		} catch (e) {
-			try {
-				const error = await DBError.generate(
-					{
-						request: req,
-						error: e instanceof Error ? e : undefined,
-					},
-					{
-						user: req.user?.id,
-					},
-				);
-				res.status(500).send(`An error occured. Error ID: ${error.id}`);
-			} catch (e) {}
-		}
+		new AdminClient()
+			.startSync(req.user)
+			.then(x => {
+				res.status(200).send();
+			})
+			.catch(e => {
+				res.status(500).send(e);
+			});
 	},
 );
 

--- a/src/webserver/routes/auth.ts
+++ b/src/webserver/routes/auth.ts
@@ -97,6 +97,20 @@ router.get(
 );
 
 router.get(
+	['/login/admin_sync', '/signin/admin_sync'],
+	(req, res, next) =>
+		request(req, res, next, {
+			authentication: false,
+		}),
+	async (req, res) => {
+		handleLogin(req, res, {
+			scopes: 'ADMIN_SYNC',
+			redirect: '/admin',
+		});
+	},
+);
+
+router.get(
 	['/logout', '/signout'],
 	(req, res, next) =>
 		request(req, res, next, {


### PR DESCRIPTION
Syncs users with Google Admin

- Adds API route to sync users with Google Admin
    - Adds option to set OU (Organization Unit, like a group of users) names that should be given the staff role automatically
    - Adds option to set OUs that should be ignored
    - Checks for updates to name, email, or OU and updates documents accordingly
    - Adds new users and removes disabled or ignored users
- Adds button to admin page to run the sync manually. The first API request is run before the API responds so that it can ensure there are no permissions issues. Besides that there is no feedback for status later on.
    - If the user has not authorized the required scope, the button will redirect them to a login page to request that scope.
- Adds option to run a sync daily at midnight. This will be run as the user specified in the config file.

Closes #35