### PR TITLE
Store item sort/filter

### DIFF
--- a/frontend/src/components/Input.svelte
+++ b/frontend/src/components/Input.svelte
@@ -95,6 +95,26 @@
 			bind:this={input}
 			{...$$restProps}
 		/>
+	{:else if type == 'select'}
+		<select
+			class="select select-bordered w-full {additionalClasses}"
+			class:input-success={error === null}
+			class:input-error={error}
+			{disabled}
+			placeholder={label}
+			on:change={handle}
+			on:focus={handle}
+			on:blur={handle}
+			on:change
+			on:keydown
+			on:focus
+			on:blur
+			bind:value
+			bind:this={input}
+			{...$$restProps}
+		>
+			<slot />
+		</select>
 	{:else}
 		<input
 			class="input input-bordered	w-full {additionalClasses}"

--- a/frontend/src/pages/store/[store].svelte
+++ b/frontend/src/pages/store/[store].svelte
@@ -105,11 +105,11 @@
 	}
 
 	const ITEM_SORTERS = {
-		name: (a, b) =>
-			ITEM_SORTERS.newArrival(a, b) || a.name.localeCompare(b.name),
-		price_asc: (a, b) => ITEM_SORTERS.newArrival(a, b) || a.price - b.price,
+		featured: (a, b) => ITEM_SORTERS.newArrival(a, b) || a.name.localeCompare(b.name),
+		name: (a, b) => a.name.localeCompare(b.name),
+		price_asc: (a, b) => a.price - b.price,
 		price_desc: (a, b) =>
-			ITEM_SORTERS.newArrival(a, b) || b.price - a.price,
+			b.price - a.price,
 		date_asc: (a, b) => new Date(a.createdAt) - new Date(b.createdAt),
 		date_desc: (a, b) => new Date(b.createdAt) - new Date(a.createdAt),
 		newArrival: (a, b) =>
@@ -120,7 +120,7 @@
 				: -1,
 	};
 
-	let selectedSorter = 'name';
+	let selectedSorter = 'featured';
 	let ACTIVE_SORTER = ITEM_SORTERS[selectedSorter];
 	let query = '';
 	let filterCanAfford = false;
@@ -528,6 +528,7 @@
 					label="Sort by"
 					bind:value={selectedSorter}
 				>
+					<option value="featured">Featured</option>
 					<option value="name">Name</option>
 					<option value="price_desc">Price (High to Low)</option>
 					<option value="price_asc">Price (Low to High)</option>

--- a/frontend/src/pages/store/[store].svelte
+++ b/frontend/src/pages/store/[store].svelte
@@ -519,9 +519,16 @@
 						class="p-4 bg-base-200 shadow rounded-lg flex flex-col"
 					>
 						<div class="flex flex-row justify-between items-center">
-							<p class="inline-flex text-3xl font-semibold">
-								{item.name}
-							</p>
+							<div
+								class="flex text-3xl font-semibold items-center"
+							>
+								<span>{item.name}</span>
+								{#if item.newArrival}
+									<div class="badge badge-secondary ml-2">
+										NEW
+									</div>
+								{/if}
+							</div>
 							{#if store.canManage}
 								<label
 									for="editmodal"

--- a/frontend/src/pages/store/[store].svelte
+++ b/frontend/src/pages/store/[store].svelte
@@ -105,9 +105,11 @@
 	}
 
 	const ITEM_SORTERS = {
-		name: (a, b) => a.name.localeCompare(b.name),
-		price_asc: (a, b) => a.price - b.price,
-		price_desc: (a, b) => b.price - a.price,
+		name: (a, b) =>
+			ITEM_SORTERS.newArrival(a, b) || a.name.localeCompare(b.name),
+		price_asc: (a, b) => ITEM_SORTERS.newArrival(a, b) || a.price - b.price,
+		price_desc: (a, b) =>
+			ITEM_SORTERS.newArrival(a, b) || b.price - a.price,
 		date_asc: (a, b) => new Date(a.createdAt) - new Date(b.createdAt),
 		date_desc: (a, b) => new Date(b.createdAt) - new Date(a.createdAt),
 		newArrival: (a, b) =>
@@ -126,9 +128,7 @@
 		ACTIVE_SORTER = ITEM_SORTERS[selectedSorter];
 		filteredItems = items;
 		if (filteredItems) {
-			filteredItems = filteredItems.sort(
-				(a, b) => ITEM_SORTERS.newArrival(a, b) || ACTIVE_SORTER(a, b),
-			);
+			filteredItems = filteredItems.sort((a, b) => ACTIVE_SORTER(a, b));
 			filteredItems = filteredItems.filter(x =>
 				[x.name, x.description].some(
 					x =>

--- a/frontend/src/pages/store/[store].svelte
+++ b/frontend/src/pages/store/[store].svelte
@@ -145,7 +145,7 @@
 	let balance = null;
 	(async () => {
 		userInfo = (await ctx) || null;
-		if (userInfo && !userInfo.roles.includes('STAFF'))
+		if (userInfo && userInfo.roles.includes('STUDENT'))
 			balance = userInfo.balance;
 	})();
 

--- a/frontend/src/pages/store/[store].svelte
+++ b/frontend/src/pages/store/[store].svelte
@@ -520,7 +520,7 @@
 				>
 			</div>
 		{/if}
-		<div class="flex space-x-2 mb-4">
+		<div class="flex space-x-4 mb-4">
 			<div>
 				<Input
 					type="select"

--- a/frontend/src/pages/store/[store].svelte
+++ b/frontend/src/pages/store/[store].svelte
@@ -123,6 +123,7 @@
 	let selectedSorter = 'name';
 	let ACTIVE_SORTER = ITEM_SORTERS[selectedSorter];
 	let query = '';
+	let filterCanAfford = false;
 
 	$: {
 		ACTIVE_SORTER = ITEM_SORTERS[selectedSorter];
@@ -136,6 +137,8 @@
 						x.toLowerCase().includes(query.trim().toLowerCase()),
 				),
 			);
+			if (filterCanAfford && balance !== null)
+				filteredItems = filteredItems.filter(x => x.price <= balance);
 		}
 	}
 
@@ -533,6 +536,16 @@
 			<div>
 				<Input class="w-auto" label="Search" bind:value={query} />
 			</div>
+			{#if balance !== null}
+				<div>
+					<Input
+						type="switch"
+						parentClass="flex items-center h-12"
+						label="Only show what I can afford"
+						bind:value={filterCanAfford}
+					/>
+				</div>
+			{/if}
 		</div>
 		{#if error || !filteredItems || filteredItems.length == 0}
 			<h2 class="text-center text-2xl">

--- a/frontend/src/pages/store/[store].svelte
+++ b/frontend/src/pages/store/[store].svelte
@@ -103,6 +103,27 @@
 		}
 	}
 
+	const ITEM_SORTERS = {
+		name: (a, b) => a.name.localeCompare(b.name),
+		price_asc: (a, b) => a.price - b.price,
+		price_desc: (a, b) => b.price - a.price,
+		newArrival: (a, b) =>
+			b.newArrival == a.newArrival
+				? 0
+				: b.newArrival && !a.newArrival
+				? 1
+				: -1,
+	};
+
+	const ACTIVE_SORTER = ITEM_SORTERS.name;
+
+	$: {
+		if (items)
+			items.sort(
+				(a, b) => ITEM_SORTERS.newArrival(a, b) || ACTIVE_SORTER(a, b),
+			);
+	}
+
 	let balance = null;
 	(async () => {
 		balance = await getBalance().catch(e => null);

--- a/frontend/src/pages/store/[store].svelte
+++ b/frontend/src/pages/store/[store].svelte
@@ -144,7 +144,9 @@
 
 	let balance = null;
 	(async () => {
-		balance = await getBalance().catch(e => null);
+		userInfo = (await ctx) || null;
+		if (userInfo && !userInfo.roles.includes('STAFF'))
+			balance = userInfo.balance;
 	})();
 
 	// Manage items

--- a/frontend/src/pages/store/[store].svelte
+++ b/frontend/src/pages/store/[store].svelte
@@ -49,6 +49,7 @@
 	let loading = false;
 	let error;
 	let items = null;
+	let filteredItems = null;
 	const LOW_STOCK = 3; //Low stock if there are this many items or less
 
 	let students = null;
@@ -115,13 +116,25 @@
 				: -1,
 	};
 
-	const ACTIVE_SORTER = ITEM_SORTERS.name;
+	let selectedSorter = 'name';
+	let ACTIVE_SORTER = ITEM_SORTERS[selectedSorter];
+	let query = '';
 
 	$: {
-		if (items)
-			items.sort(
+		ACTIVE_SORTER = ITEM_SORTERS[selectedSorter];
+		filteredItems = items;
+		if (filteredItems) {
+			filteredItems = filteredItems.sort(
 				(a, b) => ITEM_SORTERS.newArrival(a, b) || ACTIVE_SORTER(a, b),
 			);
+			filteredItems = filteredItems.filter(x =>
+				[x.name, x.description].some(
+					x =>
+						x &&
+						x.toLowerCase().includes(query.trim().toLowerCase()),
+				),
+			);
+		}
 	}
 
 	let balance = null;
@@ -500,21 +513,40 @@
 				>
 			</div>
 		{/if}
-		{#if error || !items || items.length == 0}
-			<h2 class="text-center">
+		<div class="flex space-x-2 mb-4">
+			<div>
+				<Input
+					type="select"
+					class="w-auto"
+					label="Sort by"
+					bind:value={selectedSorter}
+				>
+					<option value="name">Name</option>
+					<option value="price_asc">Price (Low to High)</option>
+					<option value="price_desc">Price (High to Low)</option>
+				</Input>
+			</div>
+			<div>
+				<Input class="w-auto" label="Search" bind:value={query} />
+			</div>
+		</div>
+		{#if error || !filteredItems || filteredItems.length == 0}
+			<h2 class="text-center text-2xl">
 				{#if error}
 					An Error Occured
 				{:else if loading && !items}
 					<Loading height="2rem" />
+				{:else if items.length > 0 && filteredItems.length == 0}
+					No results
 				{:else}
-					No Items
+					No items
 				{/if}
 			</h2>
 		{:else}
 			<div
 				class="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
 			>
-				{#each items as item}
+				{#each filteredItems as item}
 					<div
 						class="p-4 bg-base-200 shadow rounded-lg flex flex-col"
 					>

--- a/frontend/src/pages/store/[store].svelte
+++ b/frontend/src/pages/store/[store].svelte
@@ -105,11 +105,11 @@
 	}
 
 	const ITEM_SORTERS = {
-		featured: (a, b) => ITEM_SORTERS.newArrival(a, b) || a.name.localeCompare(b.name),
+		featured: (a, b) =>
+			ITEM_SORTERS.newArrival(a, b) || a.name.localeCompare(b.name),
 		name: (a, b) => a.name.localeCompare(b.name),
 		price_asc: (a, b) => a.price - b.price,
-		price_desc: (a, b) =>
-			b.price - a.price,
+		price_desc: (a, b) => b.price - a.price,
 		date_asc: (a, b) => new Date(a.createdAt) - new Date(b.createdAt),
 		date_desc: (a, b) => new Date(b.createdAt) - new Date(a.createdAt),
 		newArrival: (a, b) =>
@@ -124,6 +124,7 @@
 	let ACTIVE_SORTER = ITEM_SORTERS[selectedSorter];
 	let query = '';
 	let filterCanAfford = false;
+	let filterCollapseShown = false;
 
 	$: {
 		ACTIVE_SORTER = ITEM_SORTERS[selectedSorter];
@@ -520,35 +521,51 @@
 				>
 			</div>
 		{/if}
-		<div class="flex space-x-4 mb-4">
-			<div>
-				<Input
-					type="select"
-					class="w-auto"
-					label="Sort by"
-					bind:value={selectedSorter}
-				>
-					<option value="featured">Featured</option>
-					<option value="name">Name</option>
-					<option value="price_desc">Price (High to Low)</option>
-					<option value="price_asc">Price (Low to High)</option>
-					<option value="date_desc">Date (Newest to Oldest)</option>
-					<option value="date_asc">Date (Oldest to Newest)</option>
-				</Input>
-			</div>
-			<div>
-				<Input class="w-auto" label="Search" bind:value={query} />
-			</div>
-			{#if balance !== null}
+		<div class="collapse bg-base-200 rounded-lg collapse-arrow mb-4">
+			<input
+				type="checkbox"
+				id="filtercollapse"
+				bind:checked={filterCollapseShown}
+			/>
+			<label
+				for="filtercollapse"
+				class="collapse-title text-xl font-medium !bg-base-200"
+			>
+				{filterCollapseShown ? 'Hide' : 'Show'} filters
+			</label>
+			<div class="flex space-x-4 collapse-content !bg-base-200">
 				<div>
 					<Input
-						type="switch"
-						parentClass="flex items-center h-12"
-						label="Only show what I can afford"
-						bind:value={filterCanAfford}
-					/>
+						type="select"
+						class="w-auto"
+						label="Sort by"
+						bind:value={selectedSorter}
+					>
+						<option value="featured">Featured</option>
+						<option value="name">Name</option>
+						<option value="price_desc">Price (High to Low)</option>
+						<option value="price_asc">Price (Low to High)</option>
+						<option value="date_desc"
+							>Date (Newest to Oldest)</option
+						>
+						<option value="date_asc">Date (Oldest to Newest)</option
+						>
+					</Input>
 				</div>
-			{/if}
+				<div>
+					<Input class="w-auto" label="Search" bind:value={query} />
+				</div>
+				{#if balance !== null}
+					<div>
+						<Input
+							type="switch"
+							parentClass="flex items-center h-12"
+							label="Only show what I can afford"
+							bind:value={filterCanAfford}
+						/>
+					</div>
+				{/if}
+			</div>
 		</div>
 		{#if error || !filteredItems || filteredItems.length == 0}
 			<h2 class="text-center text-2xl">

--- a/frontend/src/pages/store/[store].svelte
+++ b/frontend/src/pages/store/[store].svelte
@@ -108,6 +108,8 @@
 		name: (a, b) => a.name.localeCompare(b.name),
 		price_asc: (a, b) => a.price - b.price,
 		price_desc: (a, b) => b.price - a.price,
+		date_asc: (a, b) => new Date(a.createdAt) - new Date(b.createdAt),
+		date_desc: (a, b) => new Date(b.createdAt) - new Date(a.createdAt),
 		newArrival: (a, b) =>
 			b.newArrival == a.newArrival
 				? 0
@@ -522,8 +524,10 @@
 					bind:value={selectedSorter}
 				>
 					<option value="name">Name</option>
-					<option value="price_asc">Price (Low to High)</option>
 					<option value="price_desc">Price (High to Low)</option>
+					<option value="price_asc">Price (Low to High)</option>
+					<option value="date_desc">Date (Newest to Oldest)</option>
+					<option value="date_asc">Date (Oldest to Newest)</option>
 				</Input>
 			</div>
 			<div>

--- a/src/struct/db/storeitem.ts
+++ b/src/struct/db/storeitem.ts
@@ -33,6 +33,19 @@ export default class StoreItem {
 	@prop()
 	imageHash?: string;
 
+	public get createdAt(): Date {
+		return (
+			this as unknown as DocumentType<typeof StoreItem>
+		)._id.getTimestamp();
+	}
+
+	public get newArrival() {
+		return (
+			(this.createdAt.getTime() || 0) >=
+			Date.now() - 1000 * 60 * 60 * 24 * 7
+		);
+	}
+
 	public static async findByStoreID(
 		this: ReturnModelType<typeof StoreItem>,
 		storeID: string,

--- a/src/webserver/routes/api/store.ts
+++ b/src/webserver/routes/api/store.ts
@@ -605,7 +605,14 @@ router.get(
 
 		let items = await StoreItem.findByStoreID(store.id);
 
-		res.status(200).json(items);
+		res.status(200).json(
+			items.map(x =>
+				x.toObject({
+					getters: true,
+					versionKey: false,
+				}),
+			),
+		);
 	},
 );
 
@@ -635,7 +642,12 @@ router.get(
 
 		if (!item) return;
 
-		res.status(200).json(item);
+		res.status(200).json(
+			item.toObject({
+				getters: true,
+				versionKey: false,
+			}),
+		);
 	},
 );
 
@@ -738,7 +750,12 @@ router.patch(
 
 			item.imageHash = hash;
 			await item.save();
-			return res.status(200).json(item);
+			return res.status(200).json(
+				item.toObject({
+					getters: true,
+					versionKey: false,
+				}),
+			);
 		} catch (e) {
 			try {
 				let error = await DBError.generate(
@@ -798,7 +815,12 @@ router.patch(
 
 			await item.save();
 
-			res.status(200).json(item);
+			res.status(200).json(
+				item.toObject({
+					getters: true,
+					versionKey: false,
+				}),
+			);
 		} catch (e) {
 			try {
 				let error = await DBError.generate(
@@ -909,7 +931,12 @@ router.delete(
 			item.imageHash = undefined;
 			await item.save();
 
-			return res.status(200).json(item);
+			return res.status(200).json(
+				item.toObject({
+					getters: true,
+					versionKey: false,
+				}),
+			);
 		} catch (e) {
 			try {
 				let error = await DBError.generate(
@@ -971,7 +998,12 @@ router.post(
 
 			if (!item) return res.status(500).send('Failed to create item');
 
-			return res.status(200).send(item);
+			return res.status(200).send(
+				item.toObject({
+					getters: true,
+					versionKey: false,
+				}),
+			);
 		} catch (e) {
 			try {
 				let error = await DBError.generate(

--- a/src/webserver/routes/api/store.ts
+++ b/src/webserver/routes/api/store.ts
@@ -463,7 +463,7 @@ router.get(
 			let permissions = await getStorePerms(store, req.user);
 			if (!permissions.manage) return res.status(403).send('Forbidden');
 
-			if (store.public) return res.status(200).send(null);
+			if (store.public) return res.status(200).json(null);
 
 			let studentIds: string[] = store.users;
 


### PR DESCRIPTION
- Add new arrivals for store items (Less than 1 week old). Will show a "new" badge next to the name.
- Add option to sort store items. Defaults to alphabetical. New arrivals will be sorted first except for date-related sort options
- Add option to search store items
- Add option to filter store to only the items the viewer can afford. Will only be visible to students.