### PR TITLE
Sync student IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,24 +54,25 @@ If you would like to watch for file changes and automatically execute the approp
 
 # Config
 
-| property         | type             | description                                | example                                |
-| ---------------- | ---------------- | ------------------------------------------ | -------------------------------------- |
-| mongo            | string           | MongoDB Connection URL                     | mongodb://user:pass@127.0.0.1:27017/db |
-| port             | number           | port to listen on                          | 8000                                   |
-| client_id        | string           | Google OAuth client ID                     |                                        |
-| client_secret    | string           | Google OAuth client secret                 |                                        |
-| oauthDomain      | string \| null   | Google OAuth domain, or null to disable    | mydomain.com                           |
-| sessionSecret    | string           | Session secret for Mongo                   |                                        |
-| weeklyBalance    | number           | Staff's weekly balance                     | 100                                    |
-| gadmin_domain    | string \| null   | Domain to use for Google Admin syncing     | mydomain.com                           |
-| gadmin_staff_ou  | string[] \| null | Staff OU names for Google Admin syncing    | ["Staff", "Some OU/Admins"]            |
-| gadmin_ignore_ou | string[] \| null | Excluded OU names for Google Admin syncing | ["Old students"]                       |
-| gadmin_sync_user | string \| null   | User to run the daily Google Admin sync as |                                        |
+| property            | type             | description                                | example                                |
+| ------------------- | ---------------- | ------------------------------------------ | -------------------------------------- |
+| mongo               | string           | MongoDB Connection URL                     | mongodb://user:pass@127.0.0.1:27017/db |
+| port                | number           | port to listen on                          | 8000                                   |
+| client_id           | string           | Google OAuth client ID                     |                                        |
+| client_secret       | string           | Google OAuth client secret                 |                                        |
+| oauthDomain         | string \| null   | Google OAuth domain, or null to disable    | mydomain.com                           |
+| sessionSecret       | string           | Session secret for Mongo                   |                                        |
+| weeklyBalance       | number           | Staff's weekly balance                     | 100                                    |
+| gadmin_domain       | string \| null   | Domain to use for Google Admin syncing     | mydomain.com                           |
+| gadmin_staff_ou     | string[] \| null | Staff OU names for Google Admin syncing    | ["Staff", "Some OU/Admins"]            |
+| gadmin_ignore_ou    | string[] \| null | Excluded OU names for Google Admin syncing | ["Old students"]                       |
+| gadmin_sync_user    | string \| null   | User to run daily Google Admin/Sheets sync |                                        |
+| sync_spreadsheet_id | string \| null   | Google Sheet for student ID sync           |                                        |
 
 ## Google Cloud Project Setup (For OAuth)
 
 1. Create a [Google Cloud Project](https://console.cloud.google.com/projectcreate)
-2. Go to APIs & Services > Library. Enable the Google Classroom API, Google People API, and Admin SDK API.
+2. Go to APIs & Services > Library. Enable the Google Classroom API, Google People API, Admin SDK API, and Google Sheets API.
 3. Go to APIs & Services > OAuth consent screen. Setup as desired.
 4. Go to APIs & Services > Credentials. Click "Create credentials" and select "OAuth client ID".
 5. Select "Web application" for the type. Add your domain to the authorized origins. For redirect URIs, add your domain with the path `/auth/cbk`.

--- a/frontend/src/pages/admin/index.svelte
+++ b/frontend/src/pages/admin/index.svelte
@@ -262,6 +262,9 @@
 			info &&
 			info.scopes.includes(
 				'https://www.googleapis.com/auth/admin.directory.user.readonly',
+			) &&
+			info.scopes.includes(
+				'https://www.googleapis.com/auth/spreadsheets.readonly',
 			)
 		)
 			hasAdminScope = true;
@@ -472,7 +475,8 @@
 					>
 				{:else}
 					<span class="mb-2 text-center"
-						>You have not authorized Kitcoin to access Google Admin.</span
+						>You have not authorized Kitcoin to access Google Admin
+						and/or Google Sheets.</span
 					>
 					<a
 						class="btn btn-primary"

--- a/src/config/keys.example.json
+++ b/src/config/keys.example.json
@@ -15,5 +15,6 @@
 		"xxxxx",
 		"xxxxx/yyyyy"
 	],
-	"gadmin_sync_user": "xxxxx"
+	"gadmin_sync_user": "xxxxx",
+	"sync_spreadsheet_id": "xxxxx"
 }

--- a/src/config/keys.ts
+++ b/src/config/keys.ts
@@ -12,6 +12,7 @@ interface Keys {
 	gadmin_staff_ou: string[] | null;
 	gadmin_ignore_ou: string[] | null;
 	gadmin_sync_user: string | null;
+	sync_spreadsheet_id: string | null;
 }
 
 let data = fs.readFileSync(new URL('./keys.json', import.meta.url).pathname);
@@ -29,6 +30,7 @@ let {
 	gadmin_staff_ou,
 	gadmin_ignore_ou,
 	gadmin_sync_user,
+	sync_spreadsheet_id,
 } = json;
 
 export {
@@ -43,4 +45,5 @@ export {
 	gadmin_staff_ou,
 	gadmin_ignore_ou,
 	gadmin_sync_user,
+	sync_spreadsheet_id,
 };

--- a/src/helpers/admin.ts
+++ b/src/helpers/admin.ts
@@ -39,7 +39,13 @@ export class AdminClient {
 				spreadsheetId: sync_spreadsheet_id,
 				range: 'A1:B',
 			})
-			.catch(e => {});
+			.catch(e => {
+				if (e && e.code && e.errors)
+					throw `Google API ${e.code}: ${e.errors
+						.map((x: any) => x.message)
+						.join(', ')}`;
+				else throw e;
+			});
 
 		if (!data || !data.data.values)
 			throw 'Could not access spreadsheet data.';

--- a/src/helpers/admin.ts
+++ b/src/helpers/admin.ts
@@ -41,9 +41,9 @@ export class AdminClient {
 			})
 			.catch(e => {
 				if (e && e.code && e.errors)
-					throw `Google API ${e.code}: ${e.errors
-						.map((x: any) => x.message)
-						.join(', ')}`;
+					throw `Error syncing spreadsheet: Google API ${
+						e.code
+					}: ${e.errors.map((x: any) => x.message).join(', ')}`;
 				else throw e;
 			});
 
@@ -137,7 +137,7 @@ export class AdminClient {
 			let users = await this.listUsers(pageToken).catch(e => {
 				if (e && e.code && e.errors)
 					reject(
-						`Google API ${e.code}: ${e.errors
+						`Error syncing admin: Google API ${e.code}: ${e.errors
 							.map((x: any) => x.message)
 							.join(', ')}`,
 					);

--- a/src/helpers/admin.ts
+++ b/src/helpers/admin.ts
@@ -47,8 +47,7 @@ export class AdminClient {
 				else throw e;
 			});
 
-		if (!data || !data.data.values)
-			throw 'Could not access spreadsheet data.';
+		if (!data || !data.data.values) return;
 
 		let rows = data.data.values.slice(1);
 

--- a/src/helpers/admin.ts
+++ b/src/helpers/admin.ts
@@ -28,6 +28,10 @@ export class AdminClient {
 		return data.data;
 	}
 
+	/**
+	 * Fetch student IDs from the spreadsheet
+	 * First column should have student IDs, second column should have student emails
+	 */
 	private async fetchStudentIDs() {
 		if (!this.token) throw 'Could not authenticate for the Google API';
 		if (!sync_spreadsheet_id) throw 'Google Admin domain not set';
@@ -49,7 +53,10 @@ export class AdminClient {
 
 		if (!data || !data.data.values) return;
 
-		let rows = data.data.values.slice(1);
+		let rows = data.data.values.slice(1) as [
+			string | undefined,
+			string | undefined,
+		][];
 
 		rows.map(async ([id, email]) => {
 			if (!email) return;

--- a/src/helpers/oauth.ts
+++ b/src/helpers/oauth.ts
@@ -12,6 +12,7 @@ const OAUTH_SCOPES = {
 	],
 	ADMIN_SYNC: [
 		'https://www.googleapis.com/auth/admin.directory.user.readonly',
+		'https://www.googleapis.com/auth/spreadsheets.readonly',
 	],
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,9 @@ import './webserver/index.js';
 // Start user sync
 let user = gadmin_sync_user as string | null;
 if (typeof user == 'string') {
-	new AdminClient().startDailySyncs(user);
+	try {
+		new AdminClient().startDailySyncs(user);
+	} catch (e) {}
 }
 
 mongoose.connect(mongo);


### PR DESCRIPTION
IDs are synced from a spreadsheet at the same time as the Google Admin sync. First column should have student IDs, second column should have emails. This also catches errors during the initial sync on process start.

I am marking this as a draft for now as the spreadsheet details may change. However, this is fully working.

Closes #67 