### PR TITLE
Partial payments

### DIFF
--- a/API-DOCS.md
+++ b/API-DOCS.md
@@ -244,7 +244,8 @@ Sell an item
 `:id` (path): Store ID  
 `user` (body): The user ID of the person buying the item  
 `item` (body): The ID of the item being sold  
-`quantity` (body): [Optional] The quantity of the item being sold
+`quantity` (body): [Optional] The quantity of the item being sold  
+`deduct` (body): [Optional] Deduct this amount from the price, for example if the user is partially paying in cash.
 
 ### Response
 

--- a/API-DOCS.md
+++ b/API-DOCS.md
@@ -168,6 +168,7 @@ Create a store. Requires staff permissions.
 `classIDs` (body): [Optional] An array of Google Classroom IDs  
 `public` (body): Whether the store is public or not. Public stores require admin permissions.  
 `pinned` (body): Whether the store is pinned or not. Pinned stores require admin permissions. The store must be public to be pinned.  
+`allowDeductions` (body): Whether deductions are allowed when selling items. Changing this setting requires admin permissions.  
 `managers` (body): An array of user IDs who can manage this store  
 `users` (body): An array of user IDs who can access this store
 
@@ -203,6 +204,7 @@ Update a store. Requires permission to manage this store.
 `classIDs` (body): [Optional] An array of Google Classroom IDs  
 `public` (body): Whether the store is public or not. Changing this setting requires admin permissions.  
 `pinned` (body): Whether the store is pinned or not. Changing this setting require admin permissions. The store must be public to be pinned.  
+`allowDeductions` (body): Whether deductions are allowed when selling items. Changing this setting requires admin permissions.  
 `managers` (body): An array of user IDs who can manage this store  
 `users` (body): An array of user IDs who can access this store  
 `owner` (body): [Optional] The user ID of the new owner of the store. Changing this setting requires admin permissions or you to be the existing owner.

--- a/frontend/src/components/Form.svelte
+++ b/frontend/src/components/Form.svelte
@@ -22,10 +22,10 @@
 		let event = e.detail;
 		if (!event) return;
 		let which = event.target.name;
+		values[which] = event.value;
 
 		let res = validators[which](event);
 
-		values[which] = event.value;
 		errors[which] = res;
 		valid[which] = res == null;
 

--- a/frontend/src/pages/store/[store].svelte
+++ b/frontend/src/pages/store/[store].svelte
@@ -993,14 +993,16 @@
 					bind:error={transactionFormData.errors.quantity}
 					on:validate={transactionForm.validate}
 				/>
-				<Input
-					name="deduct"
-					label="Deduct amount (optional)"
-					placeholder="0"
-					bind:value={transactionFormData.values.deduct}
-					bind:error={transactionFormData.errors.deduct}
-					on:validate={transactionForm.validate}
-				/>
+				{#if store && store.allowDeductions}
+					<Input
+						name="deduct"
+						label="Deduct amount (optional)"
+						placeholder="0"
+						bind:value={transactionFormData.values.deduct}
+						bind:error={transactionFormData.errors.deduct}
+						on:validate={transactionForm.validate}
+					/>
+				{/if}
 				{#if selectedItem && selectedItem.quantity !== null && selectedItem.quantity < (transactionFormData.values.quantity || 1)}
 					<div class="alert alert-warning my-4">
 						<div class="flex-1 items-center">

--- a/frontend/src/pages/store/index.svelte
+++ b/frontend/src/pages/store/index.svelte
@@ -79,6 +79,10 @@
 			let v = e.value;
 			return null;
 		},
+		allowDeductions: e => {
+			let v = e.value;
+			return null;
+		},
 		classes: e => {
 			let v = e.value?.value;
 			return null;
@@ -131,6 +135,7 @@
 			manageForm.values.classes = extraClasses;
 			manageForm.values.public = modalStore.public;
 			manageForm.values.pinned = modalStore.pinned;
+			manageForm.values.allowDeductions = modalStore.allowDeductions;
 			manageForm.values.managers = modalStore.managers.map(x => ({
 				text: x.name,
 				value: x.id,
@@ -194,6 +199,8 @@
 			manageFormData.values.public = false;
 		if (manageFormData.values.pinned == '')
 			manageFormData.values.pinned = false;
+		if (manageFormData.values.allowDeductions == '')
+			manageFormData.values.allowDeductions = false;
 
 		submitStatus = 'LOADING';
 		let res = await fetch(
@@ -215,6 +222,9 @@
 					pinned:
 						manageFormData.values.pinned ??
 						(modalStore ? modalStore.pinned : false),
+					allowDeductions:
+						manageFormData.values.allowDeductions ??
+						(modalStore ? modalStore.allowDeductions : false),
 					managers: (manageFormData.values.managers || []).map(
 						x => x.value,
 					),
@@ -493,6 +503,14 @@
 						type="switch"
 						bind:value={manageFormData.values.public}
 						bind:error={manageFormData.errors.public}
+						on:validate={manageForm.validate}
+					/>
+					<Input
+						name="allowDeductions"
+						label="Allow deductions from price when selling items"
+						type="switch"
+						bind:value={manageFormData.values.allowDeductions}
+						bind:error={manageFormData.errors.allowDeductions}
 						on:validate={manageForm.validate}
 					/>
 					<Input

--- a/src/struct/db/store.ts
+++ b/src/struct/db/store.ts
@@ -46,6 +46,12 @@ export default class Store {
 	@prop({required: true, default: false})
 	public pinned: boolean = false;
 
+	/**
+	 * Allow deductions from price when selling item
+	 */
+	@prop({required: true, default: false})
+	public allowDeductions: boolean = false;
+
 	public async toAPIResponse(
 		this: DocumentType<Store>,
 		canManage: boolean,

--- a/src/webserver/routes/api/store.ts
+++ b/src/webserver/routes/api/store.ts
@@ -211,6 +211,7 @@ router.post(
 					managers: Validators.array(Validators.objectID),
 					users: Validators.array(Validators.objectID),
 					pinned: Validators.boolean,
+					allowDeductions: Validators.boolean,
 				},
 			},
 		}),
@@ -228,6 +229,10 @@ router.post(
 				return res
 					.status(403)
 					.send('You must be an admin to create a pinned store.');
+			if (body.allowDeductions && !req.user.hasRole('ADMIN'))
+				return res
+					.status(403)
+					.send('You must be an admin to enable allowDeductions.');
 			if (!body.public && body.pinned) body.pinned = false;
 
 			let invalidUsers = (
@@ -351,6 +356,7 @@ router.patch(
 					users: Validators.array(Validators.objectID),
 					owner: Validators.optional(Validators.objectID),
 					pinned: Validators.boolean,
+					allowDeductions: Validators.boolean,
 				},
 			},
 		}),
@@ -373,6 +379,12 @@ router.patch(
 				return res
 					.status(403)
 					.send('You must be an admin to change the pinned setting.');
+			if (body.pinned !== store.pinned && !req.user.hasRole('ADMIN'))
+				return res
+					.status(403)
+					.send(
+						'You must be an admin to change the allowDeductions setting.',
+					);
 			if (!body.public && body.pinned) body.pinned = false;
 
 			if (

--- a/src/webserver/routes/api/store.ts
+++ b/src/webserver/routes/api/store.ts
@@ -628,6 +628,10 @@ router.post(
 			price *= quantity;
 
 			let deduct: number = req.body.deduct ?? 0;
+			if (deduct !== 0 && !store.allowDeductions)
+				return res
+					.status(400)
+					.send('This store does not allow price deductions');
 			if (deduct > price)
 				return res
 					.status(400)


### PR DESCRIPTION
Adds the ability to deduct from the price of a purchase in order to allow students to pay partially in cash. This option will only be shown on stores who have it enabled, and it can only be enabled by admins.

Closes #78 