### PR TITLE
Fix user tokens

### DIFF
--- a/src/helpers/admin.ts
+++ b/src/helpers/admin.ts
@@ -172,7 +172,7 @@ export class AdminClient {
 			user = newUser;
 		}
 		await getAccessToken(user);
-		if (!user.tokens.access) return;
+		if (!user.tokens?.access) return;
 		this.token = user.tokens.access;
 
 		if (sync_spreadsheet_id) {

--- a/src/helpers/oauth.ts
+++ b/src/helpers/oauth.ts
@@ -49,7 +49,8 @@ function getOAuth2Client(
  * @returns Google OAuth2 client
  */
 async function getAccessToken(user: IUser): Promise<Auth.OAuth2Client | null> {
-	if (!user.tokens.refresh) return null;
+	if (!user.tokens?.refresh) return null;
+
 	const oauth2Client = getOAuth2Client({
 		access_token: user.tokens.access,
 		refresh_token: user.tokens.refresh,

--- a/src/struct/db/user.ts
+++ b/src/struct/db/user.ts
@@ -42,7 +42,7 @@ class UserTokens {
 	 * Authorized scopes
 	 */
 	@prop({type: [String]})
-	public scopes: string[] = [];
+	public scopes?: string[];
 }
 
 function endOfWeek(): Date {
@@ -126,8 +126,8 @@ export default class User extends MongooseFuzzyClass {
 	@prop()
 	public schoolID?: string;
 
-	@prop({type: UserTokens, _id: false, required: true})
-	public tokens!: UserTokens;
+	@prop({type: UserTokens, _id: false})
+	public tokens?: UserTokens;
 
 	/**
 	 * The user's balance

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 
 import {IUser} from '../struct/index.js';
-import {UserRoleTypes} from './index.js';
+import {Modify, UserRoleTypes} from './index.js';
 
 /**
  * Options for request handling
@@ -76,7 +76,12 @@ export type RequestValidateConfig = {
 };
 
 export function requestHasUser(req: express.Request): req is express.Request & {
-	user: IUser;
+	user: Modify<
+		IUser,
+		{
+			tokens: Exclude<IUser['tokens'], undefined>;
+		}
+	>;
 } {
-	return (req.user! as IUser | undefined) != undefined;
+	return req.user !== undefined;
 }

--- a/src/webserver/routes/api/users.ts
+++ b/src/webserver/routes/api/users.ts
@@ -372,7 +372,7 @@ router.post(
 		if (!requestHasUser(req)) return;
 
 		if (
-			!req.user.tokens.scopes.includes(
+			!req.user.tokens.scopes?.includes(
 				'https://www.googleapis.com/auth/admin.directory.user.readonly',
 			)
 		)

--- a/src/webserver/routes/auth.ts
+++ b/src/webserver/routes/auth.ts
@@ -10,6 +10,7 @@ import {
 } from '../../helpers/oauth.js';
 import {request} from '../../helpers/request.js';
 import {DBError, ErrorDetail} from '../../struct/index.js';
+import {requestHasUser} from '../../types/request.js';
 
 const router = express.Router();
 
@@ -118,6 +119,8 @@ router.get(
 			authentication: true,
 		}),
 	async (req, res) => {
+		if (!requestHasUser(req)) return;
+
 		if (!req.session.token) return res.redirect('/');
 		if (req.user) {
 			req.user.tokens.session = undefined;


### PR DESCRIPTION
This fixes the issue on the beta instance where users would not be created in the database. After checking logs, I found that the issue was due to the `tokens` property being required but no value defined for it. This PR makes that property optional and updates other functions to work with the optional value.

This PR is currently deployed to the beta instance and all users were properly synced with Google Admin. I still don't know why it only happened on beta though.