### PR TITLE
Version check

### DIFF
--- a/API-DOCS.md
+++ b/API-DOCS.md
@@ -541,3 +541,22 @@ None
 ### Response
 
 None
+
+# Other
+
+## GET `/check-version`
+
+Get version info.
+
+## Request
+
+None
+
+### Response
+
+```ts
+[
+	string | null, // version
+	string | null, // package name
+]
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ COPY frontend/*.config.js frontend/*rc* frontend/index.html ./frontend/
 RUN npm run build:production
 RUN rm -rf src tsconfig.json gulpfile.js frontend/src frontend/public frontend/*.config.js frontend/*rc*
 ENV NODE_ENV production
-CMD ["node", "."]
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Create a [config file](#config) called keys.json in that direcory.
 
 ### Run
 
-Use `node .` to run. [pm2](https://pm2.keymetrics.io/) or equivalent is recommended.
+Use `npm start` to run. [pm2](https://pm2.keymetrics.io/) or equivalent is recommended.
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"type": "module",
 	"module": "esnext",
 	"scripts": {
+		"start": "node .",
 		"build": "gulp",
 		"build:dev": "gulp --dev",
 		"build:production": "gulp --production",

--- a/src/webserver/routes/api/misc.ts
+++ b/src/webserver/routes/api/misc.ts
@@ -40,4 +40,9 @@ router.get(
 	},
 );
 
+router.get('/check-version', (req, res) => {
+	let info = [process.env.npm_package_version, process.env.npm_package_name];
+	res.json(info);
+});
+
 export default router;


### PR DESCRIPTION
Added a version check endpoint at `/api/check-version`

This uses some env variables from npm, so we switch to running with `npm start` to get them