### PR TITLE
Fix crash on Google Admin sync

### DIFF
--- a/src/helpers/admin.ts
+++ b/src/helpers/admin.ts
@@ -176,10 +176,10 @@ export class AdminClient {
 		this.token = user.tokens.access;
 
 		if (sync_spreadsheet_id) {
-			await this.fetchStudentIDs();
+			await this.fetchStudentIDs().catch(error => console.error('fetchStudentIDs failed:', error));
 		}
 		if (gadmin_domain) {
-			return this.processAllUsers();
+			return this.processAllUsers().catch(error => console.error('processAllUsers failed:', error));
 		}
 	}
 


### PR DESCRIPTION
Fixes #100 

The problem was that we were doing `reject` within a promise but not using `.catch`, leaving errors unhandled (even by try/catch blocks)