### PR TITLE
Sync fix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose';
+import cluster from 'cluster';
 
 import {gadmin_sync_user, mongo} from './config/keys.js';
 import {AdminClient} from './helpers/admin.js';
@@ -8,7 +9,7 @@ import './webserver/index.js';
 
 // Start user sync
 let user = gadmin_sync_user as string | null;
-if (typeof user == 'string') {
+if (typeof user == 'string' && cluster.isPrimary) {
 	try {
 		new AdminClient().startDailySyncs(user);
 	} catch (e) {}


### PR DESCRIPTION
Previously, Kitcoin would run a sync for all cores the system had available.
These cores could crash due to an `UnhandledPromiseRejection` if there ever happened to be an error from Google (Ex: 500)

These changes force Kitcoin to only sync on the primary core, and make it properly handle errors when we have to use recursion to process a large number of users.

What this means is that errors will happen less often, and when they do, they'll be caught:
![image](https://github.com/codeths/kitcoin/assets/37093293/dda3bf9c-941d-4da5-b026-9ecc008d6036)
